### PR TITLE
Add support for SHA256

### DIFF
--- a/Sodium/SHA256Hash.swift
+++ b/Sodium/SHA256Hash.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Clibsodium
+
+public struct SHA256Hash {
+    public let Bytes = Int(crypto_hash_sha256_bytes())
+}
+
+extension SHA256Hash {
+    /**
+     Computes short but unpredictable (without knowing the secret key) values suitable for picking a list in a hash table for a given key.
+
+     - Parameter message: The data to be hashed.
+
+     - Returns: The computed SHA256 hash.
+     */
+    public func hash(message: Bytes) -> Bytes? {
+        var output = Array<UInt8>(count: Bytes)
+
+        guard .SUCCESS == crypto_hash_sha256 (
+            &output,
+            message, UInt64(message.count)
+        ).exitCode else { return nil }
+        return output
+    }
+}

--- a/Sodium/Sodium.swift
+++ b/Sodium/Sodium.swift
@@ -9,6 +9,7 @@ public struct Sodium {
     public let randomBytes = RandomBytes()
     public let shortHash = ShortHash()
     public let sign = Sign()
+    public let sha256Hash = SHA256Hash()
     public let utils = Utils()
     public let keyExchange = KeyExchange()
     public let auth = Auth()

--- a/Tests/SodiumTests/SodiumTests.swift
+++ b/Tests/SodiumTests/SodiumTests.swift
@@ -30,6 +30,7 @@ class SodiumTests: XCTestCase {
         ("testPad", testPad),
         ("testPwHash", testPwHash),
         ("testRandomBytes", testRandomBytes),
+        ("testSHA256Hash", testSHA256Hash),
         ("testSecretBox", testSecretBox),
         ("testSecretStream", testSecretStream),
         ("testShortHash", testShortHash),
@@ -265,6 +266,13 @@ class SodiumTests: XCTestCase {
 
         XCTAssertFalse(sodium.pwHash.strNeedsRehash(hash: hash!, opsLimit: sodium.pwHash.OpsLimitInteractive, memLimit: sodium.pwHash.MemLimitInteractive))
         XCTAssertTrue(sodium.pwHash.strNeedsRehash(hash: hash!, opsLimit: sodium.pwHash.OpsLimitSensitive, memLimit: sodium.pwHash.MemLimitSensitive))
+    }
+
+    func testSHA256Hash() {
+        XCTAssertEqual(
+            sodium.utils.bin2hex(sodium.sha256Hash.hash(message: "hello there general kenobi".bytes)!)!,
+            "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4"
+        )
     }
 
     func testKeyExchange() {


### PR DESCRIPTION
This is exposing SHA256 from `libsodium` in `swift-sodium` so we can use it in `arc` across platforms.