### PR TITLE
Add `Sendable` conformance to `SHA256Hash`

### DIFF
--- a/Sodium/SHA256Hash.swift
+++ b/Sodium/SHA256Hash.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Clibsodium
 
-public struct SHA256Hash {
+public struct SHA256Hash: Sendable {
     public let Bytes = Int(crypto_hash_sha256_bytes())
 }
 


### PR DESCRIPTION
Just adds trivial `Sendable` conformance to `SHA256Hash` to fix warnings in Xcode 15.3.